### PR TITLE
Update dependencies to release Knurling session 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,2 @@
+[workspace]
+members = ["core", "drivers/*"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -12,6 +12,9 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 once_cell = { version = "1", optional = true }
 
+[dev-dependencies]
+once_cell = "1"
+
 [features]
 default = []
 u128 = []

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 license = "MIT OR Apache-2.0"
 
 [dependencies.once_cell]
-version = "1.8.0"
+version = "1"
 optional = true
 
 [features]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -4,17 +4,13 @@ version = "0.2.5"
 description = "A rolling timer abstraction"
 repository = "https://github.com/jamesmunns/groundhog"
 authors = ["James Munns <james.munns@ferrous-systems.com>"]
-edition = "2018"
+edition = "2021"
 readme = "../README.md"
-categories = [
-    "embedded",
-    "no-std",
-]
+categories = ["embedded", "no-std"]
 license = "MIT OR Apache-2.0"
 
-[dependencies.once_cell]
-version = "1"
-optional = true
+[dependencies]
+once_cell = { version = "1", optional = true }
 
 [features]
 default = []

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -4,16 +4,13 @@
 //!
 //! Make sure you poll it often enough.
 
-#![cfg_attr(
-    not(any(test, feature = "std")),
-    no_std
-)]
-
-use core::ops::Div;
-use sealed::{Promote, RollingSince};
+#![cfg_attr(not(any(test, doctest, feature = "std")), no_std)]
 
 #[cfg(any(test, doctest, feature = "std"))]
 pub mod std_timer;
+
+use core::ops::Div;
+use sealed::{Promote, RollingSince};
 
 pub trait RollingTimer {
     type Tick: RollingSince + Promote + Div<Output = Self::Tick>;

--- a/core/src/std_timer.rs
+++ b/core/src/std_timer.rs
@@ -1,10 +1,8 @@
 use crate::RollingTimer;
-use std::time::{Instant, Duration};
+use std::time::{Duration, Instant};
 
 use once_cell::sync::Lazy;
-static T0: Lazy<Instant> = Lazy::new(|| {
-    Instant::now()
-});
+static T0: Lazy<Instant> = Lazy::new(|| Instant::now());
 
 #[derive(Default, Clone)]
 pub struct Timer<const TPS: u32>;
@@ -18,8 +16,7 @@ impl<const TPS: u32> Timer<TPS> {
     }
 }
 
-impl<const TPS: u32> RollingTimer for Timer<TPS>
-{
+impl<const TPS: u32> RollingTimer for Timer<TPS> {
     type Tick = u32;
     const TICKS_PER_SECOND: Self::Tick = TPS;
 
@@ -40,9 +37,12 @@ impl<const TPS: u32> RollingTimer for Timer<TPS>
 
 #[cfg(test)]
 mod test {
+    use std::{
+        thread::sleep,
+        time::{Duration, Instant},
+    };
+
     use super::Timer;
-    use std::time::{Instant, Duration};
-    use std::thread::sleep;
     use crate::RollingTimer;
 
     #[test]
@@ -54,13 +54,8 @@ mod test {
         let stop_gh = timer.millis_since(start_gh);
         let stop = start.elapsed();
 
-        assert!(
-            (stop >= Duration::from_millis(998))
-            && (stop <= Duration::from_millis(1002))
-        );
-        assert!(
-            (stop_gh >= 998) && (stop_gh <= 1002)
-        );
+        assert!((stop >= Duration::from_millis(998)) && (stop <= Duration::from_millis(1002)));
+        assert!((stop_gh >= 998) && (stop_gh <= 1002));
     }
 
     #[test]
@@ -72,13 +67,8 @@ mod test {
         let stop_gh = timer.millis_since(start_gh);
         let stop = start.elapsed();
 
-        assert!(
-            (stop >= Duration::from_millis(998))
-            && (stop <= Duration::from_millis(1002))
-        );
-        assert!(
-            (stop_gh >= 998) && (stop_gh <= 1002)
-        );
+        assert!((stop >= Duration::from_millis(998)) && (stop <= Duration::from_millis(1002)));
+        assert!((stop_gh >= 998) && (stop_gh <= 1002));
     }
 
     #[test]
@@ -90,12 +80,7 @@ mod test {
         let stop_gh = timer.millis_since(start_gh);
         let stop = start.elapsed();
 
-        assert!(
-            (stop >= Duration::from_millis(998))
-            && (stop <= Duration::from_millis(1002))
-        );
-        assert!(
-            (stop_gh >= 998) && (stop_gh <= 1002)
-        );
+        assert!((stop >= Duration::from_millis(998)) && (stop <= Duration::from_millis(1002)));
+        assert!((stop_gh >= 998) && (stop_gh <= 1002));
     }
 }

--- a/drivers/groundhog-nrf52/Cargo.toml
+++ b/drivers/groundhog-nrf52/Cargo.toml
@@ -14,9 +14,9 @@ categories = [
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-cortex-m-rtic = "0.5.5"
-nrf52840-hal = "0.14.0"
-embedded-hal = "0.2.4"
+cortex-m-rtic = "0.5"
+nrf52840-hal = "0.16"
+embedded-hal = "0.2"
 
 [dependencies.groundhog]
 version = "0.2.5"

--- a/drivers/groundhog-nrf52/Cargo.toml
+++ b/drivers/groundhog-nrf52/Cargo.toml
@@ -1,28 +1,22 @@
 [package]
 name = "groundhog-nrf52"
-version = "0.4.0"
+version = "0.4.0"                                           # TODO: bump
 description = "A rolling timer abstraction for the nrf52"
 repository = "https://github.com/jamesmunns/groundhog"
 authors = ["James Munns <james.munns@ferrous-systems.com>"]
-edition = "2018"
+edition = "2021"
 readme = "../../README.md"
 
-categories = [
-    "embedded",
-    "no-std",
-]
+categories = ["embedded", "no-std"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-cortex-m-rtic = "0.5"
-nrf52840-hal = "0.16"
+cortex-m-rtic = "1"
 embedded-hal = "0.2"
-
-[dependencies.groundhog]
-version = "0.2.5"
-path = "../../core"
+nrf52840-hal = "0.16"
+groundhog = { version = "0.2.5", path = "../../core" }
 
 [features]
-# TODO: Support other nrf52 flavors
-52840 = []
 default = ["52840"]
+52840 = []
+# TODO: Support other nrf52 flavors

--- a/drivers/groundhog-nrf52/src/lib.rs
+++ b/drivers/groundhog-nrf52/src/lib.rs
@@ -39,10 +39,10 @@
 //!
 #![no_std]
 
+use embedded_hal::blocking::delay::{DelayMs, DelayUs};
 use groundhog::RollingTimer;
 use nrf52840_hal::{pac::timer0::RegisterBlock as RegBlock0, timer::Instance};
-use rtic::{Fraction, Monotonic};
-use embedded_hal::blocking::delay::{DelayUs, DelayMs};
+use rtic::Monotonic;
 
 use core::sync::atomic::{AtomicPtr, Ordering};
 
@@ -76,26 +76,28 @@ impl GlobalRollingTimer {
 
 impl Monotonic for GlobalRollingTimer {
     type Instant = i32;
+    type Duration = i32;
 
-    fn ratio() -> Fraction {
-        Fraction {
-            numerator: 64,
-            denominator: 1,
-        }
-    }
-
-    fn now() -> Self::Instant {
-        Self::new().get_ticks() as i32
+    fn now(&mut self) -> Self::Instant {
+        self.get_ticks() as i32
     }
 
     fn zero() -> Self::Instant {
         0
     }
 
-    unsafe fn reset() {
+    unsafe fn reset(&mut self) {
         if let Some(t0) = TIMER_PTR.load(Ordering::SeqCst).as_ref() {
             t0.tasks_clear.write(|w| w.bits(1));
         }
+    }
+
+    fn set_compare(&mut self, _instant: Self::Instant) {
+        todo!()
+    }
+
+    fn clear_compare_flag(&mut self) {
+        todo!()
     }
 }
 
@@ -120,7 +122,7 @@ impl RollingTimer for GlobalRollingTimer {
 impl DelayUs<u32> for GlobalRollingTimer {
     fn delay_us(&mut self, us: u32) {
         let start = self.get_ticks();
-        while self.ticks_since(start) < us { }
+        while self.ticks_since(start) < us {}
     }
 }
 

--- a/drivers/groundhog-nrf52/src/lib.rs
+++ b/drivers/groundhog-nrf52/src/lib.rs
@@ -10,13 +10,13 @@
 //! To use the the `GlobalRollingTimer` with RTIC, it first needs to be selected
 //! as the monotonic timer (here on top of the nrf52840 hal):
 //!
-//! ```
+//! ```ignore
 //! #[rtic::app(device = nrf52840_hal::pac, peripherals = true, monotonic = groundhog_nrf52::GlobalRollingTimer)]
 //! ```
 //!
 //! During the init phase it needs to be initialized with a concrete timer implementation:
 //!
-//! ```
+//! ```ignore
 //! #[init]
 //! fn init(ctx: init::Context) -> init::LateResources {
 //!     // using TIMER0 here
@@ -27,7 +27,7 @@
 //!
 //! Then, you can specify the schedule interval in microseconds as part of your task:
 //!
-//! ```
+//! ```ignore
 //! #[task]
 //! fn my_task(ctx: my_task::Context) {
 //!     ctx.schedule


### PR DESCRIPTION
Hello James!
We are fixing the Knurling session written back in 2021 and would need to bump some dependencies to avoid patching in the Cargo file. Is it ok to make this release?
Thank you 🙏🏾 !